### PR TITLE
Allow registration of client id on UDS

### DIFF
--- a/implementation/endpoints/src/credentials.cpp
+++ b/implementation/endpoints/src/credentials.cpp
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 
 #include <cerrno>
 #include <cstring>
@@ -21,28 +21,38 @@
 namespace vsomeip_v3 {
 
 void credentials::activate_credentials(const int _fd) {
+#ifdef __QNX__
+    // Skip activation on QNX
+#else
     int optval = 1;
     if (setsockopt(_fd, SOL_SOCKET, SO_PASSCRED, &optval, sizeof(optval)) == -1) {
         VSOMEIP_ERROR << __func__ << ": vSomeIP Security: Activating socket option for receiving "
                       << "credentials failed.";
     }
+#endif
 }
 
 void credentials::deactivate_credentials(const int _fd) {
+#ifdef __QNX__
+    // Skip deactivation on QNX
+#else
     int optval = 0;
     if (setsockopt(_fd, SOL_SOCKET, SO_PASSCRED, &optval, sizeof(optval)) == -1) {
         VSOMEIP_ERROR << __func__ << ": vSomeIP Security: Deactivating socket option for receiving "
                       << "credentials failed.";
     }
+#endif
 }
 
 boost::optional<credentials::received_t> credentials::receive_credentials(const int _fd) {
     struct msghdr msgh;
     struct iovec iov[2];
+#ifndef __QNX__
     union {
         struct cmsghdr cmh;
         char   control[CMSG_SPACE(sizeof(struct ucred))];
     } control_un;
+#endif
 
     // We don't need address of peer as we using connect
     msgh.msg_name = NULL;
@@ -52,9 +62,15 @@ boost::optional<credentials::received_t> credentials::receive_credentials(const 
     msgh.msg_iov = iov;
     msgh.msg_iovlen = 2;
 
+#if defined(__QNX__)
+    // QNX: Skip ancillary data
+    msgh.msg_control = NULL;
+    msgh.msg_controllen = 0;
+#else
     // Set 'msgh' fields to describe 'control_un'
     msgh.msg_control = control_un.control;
     msgh.msg_controllen = sizeof(control_un.control);
+#endif
 
     // Sender client_id and client_host_length will be received as data
     client_t client = VSOMEIP_ROUTING_CLIENT;
@@ -64,10 +80,12 @@ boost::optional<credentials::received_t> credentials::receive_credentials(const 
     iov[1].iov_base = &client_host_length;
     iov[1].iov_len = sizeof(uint8_t);
 
+#ifndef __QNX__
     // Set 'control_un' to describe ancillary data that we want to receive
     control_un.cmh.cmsg_len = CMSG_LEN(sizeof(struct ucred));
     control_un.cmh.cmsg_level = SOL_SOCKET;
     control_un.cmh.cmsg_type = SCM_CREDENTIALS;
+#endif
 
     // Receive client_id plus client_host_length plus ancillary data
     ssize_t nr = recvmsg(_fd, &msgh, 0);
@@ -76,6 +94,7 @@ boost::optional<credentials::received_t> credentials::receive_credentials(const 
         return boost::none;
     }
 
+#ifndef __QNX__
     struct cmsghdr* cmhp = CMSG_FIRSTHDR(&msgh);
     if (cmhp == NULL || cmhp->cmsg_len != CMSG_LEN(sizeof(struct ucred))
             || cmhp->cmsg_level != SOL_SOCKET || cmhp->cmsg_type != SCM_CREDENTIALS) {
@@ -85,6 +104,7 @@ boost::optional<credentials::received_t> credentials::receive_credentials(const 
 
     // Use the implicitly-defined copy constructor
     struct ucred ucred = *reinterpret_cast<struct ucred*>(CMSG_DATA(cmhp));
+#endif
 
     msgh.msg_iov = iov;
     msgh.msg_iovlen = 1;
@@ -102,7 +122,11 @@ boost::optional<credentials::received_t> credentials::receive_credentials(const 
         return boost::none;
     }
 
+#ifndef __QNX__
     return received_t{client, ucred.uid, ucred.gid, client_host};
+#else
+    return received_t{client, ANY_UID, ANY_GID, client_host};
+#endif
 }
 
 void credentials::send_credentials(const int _fd, client_t _client, std::string _client_host) {
@@ -137,4 +161,4 @@ void credentials::send_credentials(const int _fd, client_t _client, std::string 
 
 } // namespace vsomeip_v3
 
-#endif // __linux__ || ANDROID
+#endif // __linux__ || ANDROID || __QNX__

--- a/implementation/endpoints/src/local_uds_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_client_endpoint_impl.cpp
@@ -11,9 +11,7 @@
 #include <vsomeip/defines.hpp>
 #include <vsomeip/internal/logger.hpp>
 
-#ifndef __QNX__
 #include "../include/credentials.hpp"
-#endif
 #include "../include/endpoint_host.hpp"
 #include "../include/local_uds_client_endpoint_impl.hpp"
 #include "../include/local_uds_server_endpoint_impl.hpp"
@@ -128,7 +126,6 @@ void local_uds_client_endpoint_impl::connect() {
             socket_->connect(remote_, its_connect_error);
 
             // Credentials
-            #ifndef __QNX__
             if (!its_connect_error) {
                 auto its_host = endpoint_host_.lock();
                 if (its_host) {
@@ -141,7 +138,6 @@ void local_uds_client_endpoint_impl::connect() {
                         << its_connect_error.message() << " / " << std::dec
                         << its_connect_error.value() << ")";
             }
-            #endif
         } else {
             VSOMEIP_WARNING << "local_client_endpoint::connect: Error opening socket: "
                     << its_error.message() << " (" << std::dec << its_error.value()

--- a/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
@@ -12,9 +12,7 @@
 
 #include <vsomeip/internal/logger.hpp>
 
-#ifndef __QNX__
 #include "../include/credentials.hpp"
-#endif
 #include "../include/endpoint_host.hpp"
 #include "../include/local_uds_server_endpoint_impl.hpp"
 #include "../include/local_server_endpoint_impl_receive_op.hpp"
@@ -64,13 +62,12 @@ local_uds_server_endpoint_impl::local_uds_server_endpoint_impl(
     if (ec)
         VSOMEIP_ERROR << __func__
             << ": listen failed (" << ec.message() << ")";
-#ifndef __QNX__
+
     if (chmod(_local.path().c_str(),
             static_cast<mode_t>(_configuration->get_permissions_uds())) == -1) {
         VSOMEIP_ERROR << __func__ << ": chmod: " << strerror(errno);
     }
     credentials::activate_credentials(acceptor_.native_handle());
-#endif
 }
 
 local_uds_server_endpoint_impl::local_uds_server_endpoint_impl(
@@ -95,13 +92,11 @@ local_uds_server_endpoint_impl::local_uds_server_endpoint_impl(
        VSOMEIP_ERROR << __func__
            << ": assign failed (" << ec.message() << ")";
 
-#ifndef __QNX__
     if (chmod(_local.path().c_str(),
             static_cast<mode_t>(_configuration->get_permissions_uds())) == -1) {
        VSOMEIP_ERROR << __func__ << ": chmod: " << strerror(errno);
     }
     credentials::activate_credentials(acceptor_.native_handle());
-#endif
 }
 
 local_uds_server_endpoint_impl::~local_uds_server_endpoint_impl() {
@@ -279,7 +274,6 @@ void local_uds_server_endpoint_impl::accept_cbk(
     }
 
     if (!_error) {
-#ifndef __QNX__
         auto its_host = endpoint_host_.lock();
         client_t its_client = 0;
         std::string its_client_host;
@@ -374,7 +368,6 @@ void local_uds_server_endpoint_impl::accept_cbk(
             }
             _connection->set_bound_client_host(its_client_host);
         }
-#endif
         _connection->start();
     }
 }


### PR DESCRIPTION
# Bug
Experiment 1:
1. Start notify-sample example from vsomeip repo. notify sample process hosts the routing manager
2. start subscribe_sample example from vsomeip repo.
Observation: notifications are received by subscribe_sample

Experiment 2:
1. Start subscribe_sample example from vsomeip repo. subscribe_sample process hosts the routing manager
2. start notify_sample example from vsomeip repo
Observation: notifications are NOT received by subscribe_sample app

# Cause 
Cliend ID was not registered/added to the list of known clients and therefore notifications could not be received by subscribe sample.
This implementation was wrapped in #ifndef __QNX__ which would cause this bug to appear for QNX.

# Fix
Remove the #ifndef __QNX__ wrapper and fixed the credentials.cpp code which handles sending and receiving ID through sendmsg() and recvmsg().

# Result
Subscribe sample example now received notification from notify sample example.
[qnx-vsomeip-example.log](https://github.com/user-attachments/files/21536669/qnx-vsomeip-example.log)
